### PR TITLE
feat(cmd): Adds `Codec` interface

### DIFF
--- a/cmd/bbctl/edit/edit.go
+++ b/cmd/bbctl/edit/edit.go
@@ -10,13 +10,14 @@ var (
 	wait               bool
 	waitTimeoutSeconds uint64
 	resourceLabels     map[string]string
+	output             string
 )
 
 var editCmd *cobra.Command
 
 func NewCmdEdit(cfg *client.Config) *cobra.Command {
 	editCmd = &cobra.Command{
-		Use:     "edit",
+		Use:     "edit NAME",
 		Short:   "Edit a resource",
 		Long:    "Edit a resource",
 		Example: `bbctl edit set`,
@@ -26,6 +27,7 @@ func NewCmdEdit(cfg *client.Config) *cobra.Command {
 	editCmd.PersistentFlags().BoolVarP(&wait, "wait", "w", true, "Wait for command to finish")
 	editCmd.PersistentFlags().Uint64VarP(&waitTimeoutSeconds, "timeout", "", 30, "How long in seconds to wait for container to start before giving up")
 	editCmd.PersistentFlags().StringToStringVarP(&resourceLabels, "labels", "l", map[string]string{}, "Resource labels as key value pair")
+	editCmd.PersistentFlags().StringVarP(&output, "output", "o", "json", "Output format")
 	editCmd.AddCommand(NewCmdEditContainer(cfg))
 
 	return editCmd

--- a/go.mod
+++ b/go.mod
@@ -52,6 +52,7 @@ require (
 	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/fsnotify/fsnotify v1.9.0 // indirect
+	github.com/ghodss/yaml v1.0.0 // indirect
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -144,6 +144,7 @@ github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSw
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/fsnotify/fsnotify v1.9.0 h1:2Ml+OJNzbYCTzsxtv8vKSFD9PbJjmhYF14k/jKC7S9k=
 github.com/fsnotify/fsnotify v1.9.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8TRcHyHii0=
+github.com/ghodss/yaml v1.0.0 h1:wQHKEahhL6wmXdzwWG11gIVCkOv05bNOh+Rxn0yngAk=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=

--- a/pkg/cmdutil/serializer.go
+++ b/pkg/cmdutil/serializer.go
@@ -1,0 +1,118 @@
+package cmdutil
+
+import (
+	"encoding/json"
+
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/proto"
+
+	// "gopkg.in/yaml.v3"
+	"github.com/ghodss/yaml"
+)
+
+type Codec interface {
+	Serializer
+	Deserializer
+}
+
+type Serializer interface {
+	Serialize(m proto.Message) ([]byte, error)
+}
+
+type Deserializer interface {
+	Deserialize(b []byte, m proto.Message) error
+}
+
+type JSONSerializer struct{}
+
+func (s *JSONSerializer) Serialize(m proto.Message) ([]byte, error) {
+	marshaler := protojson.MarshalOptions{
+		EmitUnpopulated: false,
+		Indent:          "  ",
+	}
+	b, err := marshaler.Marshal(m)
+	if err != nil {
+		return nil, err
+	}
+	return b, err
+}
+
+type YamlSerializer struct{}
+
+func (s *YamlSerializer) Serialize(m proto.Message) ([]byte, error) {
+	jsonSerializer := &JSONSerializer{}
+	jsonb, err := jsonSerializer.Serialize(m)
+	if err != nil {
+		return nil, err
+	}
+
+	var v any
+	if err := json.Unmarshal(jsonb, &v); err != nil {
+		return nil, err
+	}
+
+	// marshal to YAML
+	yamlb, err := yaml.JSONToYAML(jsonb)
+	if err != nil {
+		return nil, err
+	}
+
+	return yamlb, nil
+}
+
+type TableSerializer struct{}
+
+func (s *TableSerializer) Serialize(m proto.Message) ([]byte, error) {
+	return nil, nil
+}
+
+type JSONDeserializer struct{}
+
+func (d *JSONDeserializer) Deserialize(b []byte, m proto.Message) error {
+	unmarshaller := protojson.UnmarshalOptions{
+		DiscardUnknown: true,
+	}
+	return unmarshaller.Unmarshal(b, m)
+}
+
+type YamlDeserializer struct{}
+
+func (d *YamlDeserializer) Deserialize(b []byte, m proto.Message) error {
+	var v any
+	if err := yaml.Unmarshal(b, &v); err != nil {
+		return err
+	}
+
+	// generic Go value → JSON bytes
+	jsonb, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	jsonDeserializer := &JSONDeserializer{}
+	return jsonDeserializer.Deserialize(jsonb, m)
+}
+
+type JSONCodec struct {
+	*JSONSerializer
+	*JSONDeserializer
+}
+
+func NewJSONCodec() Codec {
+	return &JSONCodec{
+		&JSONSerializer{},
+		&JSONDeserializer{},
+	}
+}
+
+type YamlCodec struct {
+	*YamlSerializer
+	*YamlDeserializer
+}
+
+func NewYamlCodec() Codec {
+	return &YamlCodec{
+		&YamlSerializer{},
+		&YamlDeserializer{},
+	}
+}


### PR DESCRIPTION
- `Codec` allows for serialization and deserialization of API objects. Consists of a `Serializer` as well as a `Deserializer`
- `edit` commands get a persistent flag; `--output`. Sets up a codec from the flag.

  Closes #84