### PR TITLE
chore(test): Use `grpc.NewClient` over `grpc.Dial`

### DIFF
--- a/services/container/container_test.go
+++ b/services/container/container_test.go
@@ -122,7 +122,7 @@ func Test_ContainerService_Status(t *testing.T) {
 	ctx := context.Background()
 
 	//nolint:staticcheck
-	conn, err := grpc.Dial("bufnet", grpc.WithContextDialer(bufDialer), grpc.WithTransportCredentials(insecure.NewCredentials()))
+	conn, err := grpc.NewClient("passthrough://bufnet", grpc.WithContextDialer(bufDialer), grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
 		t.Fatalf("Failed to dial bufnet: %v", err)
 	}
@@ -188,7 +188,7 @@ func Test_ContainerService_Equal(t *testing.T) {
 	ctx := context.Background()
 
 	//nolint:staticcheck
-	conn, err := grpc.Dial("bufnet", grpc.WithContextDialer(bufDialer), grpc.WithTransportCredentials(insecure.NewCredentials()))
+	conn, err := grpc.NewClient("passthrough://bufnet", grpc.WithContextDialer(bufDialer), grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
 		t.Fatalf("Failed to dial bufnet: %v", err)
 	}
@@ -290,7 +290,7 @@ func Test_ContainerService_Patch(t *testing.T) {
 	ctx := context.Background()
 
 	//nolint:staticcheck
-	conn, err := grpc.Dial("bufnet", grpc.WithContextDialer(bufDialer), grpc.WithTransportCredentials(insecure.NewCredentials()))
+	conn, err := grpc.NewClient("passthrough://bufnet", grpc.WithContextDialer(bufDialer), grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
 		t.Fatalf("Failed to dial bufnet: %v", err)
 	}


### PR DESCRIPTION
- `grpc.Dial` is deprecated

Fixes #67 