### PR TITLE
feat(scheduler): reschedule tasks on node deletion

### DIFF
--- a/deploy/node.yaml
+++ b/deploy/node.yaml
@@ -54,6 +54,8 @@ spec:
             - name: DOCKER_TLS_CERTDIR
               value: ""
           volumeMounts:
+            - name: data
+              mountPath: /var/lib/voiyd
             - name: containerd-storage
               mountPath: /var/lib/containerd
             - name: docker-storage

--- a/pkg/controller/node/node.go
+++ b/pkg/controller/node/node.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/amimof/voiyd/pkg/client"
 	"github.com/amimof/voiyd/pkg/condition"
-	"github.com/amimof/voiyd/pkg/consts"
 	errs "github.com/amimof/voiyd/pkg/errors"
 	"github.com/amimof/voiyd/pkg/events"
 	"github.com/amimof/voiyd/pkg/logger"
@@ -251,6 +250,9 @@ func (c *Controller) renewAllLeases(ctx context.Context) {
 func (c *Controller) Reconcile(ctx context.Context) error {
 	nodeID := c.node.GetMeta().GetName()
 
+	// Renew leases on boot
+	c.renewAllLeases(ctx)
+
 	// Get running tasks from runtime
 	runtimeTasks, err := c.runtime.List(ctx)
 	if err != nil {
@@ -263,7 +265,7 @@ func (c *Controller) Reconcile(ctx context.Context) error {
 		taskID := task.GetMeta().GetName()
 
 		// Only acquire if task is supposed to be running
-		if task.GetStatus().GetPhase().GetValue() != consts.PHASERUNNING {
+		if task.GetStatus().GetPhase().GetValue() != string(condition.ReasonRunning) {
 			c.logger.Debug("skip lease acquisition because task is not running", "task", taskID)
 			continue
 		}


### PR DESCRIPTION
- Add logic to release leases and reschedule tasks when a node is deleted.
- Clean up node streams on delete/forget. This needs more work

Fixed #155 